### PR TITLE
Add Zarf after actions deployment example

### DIFF
--- a/examples/after-deployment-validation/README.md
+++ b/examples/after-deployment-validation/README.md
@@ -1,0 +1,21 @@
+# After Deployment Validation
+
+This example shows how Zarf component actions can be used to validate a deployment against the cluster using Kubectl.
+We use the following `actions` block to run a script that validates `Podinfo` has been
+successfully deployed.
+
+``` yaml 
+  actions:
+    onDeploy:
+      after:
+      - cmd: ./validate-podinfo.sh
+```
+
+To include a script with the Zarf package we use the following `files` block, which bundles the shell script and unzips it to the working directory during the deploy.
+
+``` yaml
+  files:
+  - source: ./validate-podinfo.sh
+    target: ./validate-podinfo.sh
+    executable: true
+```

--- a/examples/after-deployment-validation/validate-podinfo.sh
+++ b/examples/after-deployment-validation/validate-podinfo.sh
@@ -1,0 +1,4 @@
+while [[ $(kubectl get pods -n podinfo -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+  echo "waiting for pod" && sleep 1
+done
+kubectl get all -n podinfo

--- a/examples/after-deployment-validation/zarf.yaml
+++ b/examples/after-deployment-validation/zarf.yaml
@@ -1,0 +1,25 @@
+kind: ZarfPackageConfig
+metadata:
+  name: after-deployment-validation
+  description: Example of Zarf validating deployment using component actions
+  version: v1.0.0
+  architecture: arm64
+components:
+- name: after-deployment-validation
+  required: true
+  actions:
+    onDeploy:
+      after:
+      - cmd: ./validate-podinfo.sh
+  files:
+  - source: ./validate-podinfo.sh
+    target: ./validate-podinfo.sh
+    executable: true
+  charts:
+  - name: podinfo
+    releaseName: podinfo
+    url: https://stefanprodan.github.io/podinfo
+    version: 6.1.6
+    namespace: podinfo
+  images:
+  - ghcr.io/stefanprodan/podinfo:6.1.6


### PR DESCRIPTION
Adds a basic Zarf deployment with podinfo setup and working and make use of component actions to validate that the deployment was successful.