### PR TITLE
Update: Fixing typo of dos-games-test to dos-games.test 

### DIFF
--- a/examples/dos-games/zarf.yaml
+++ b/examples/dos-games/zarf.yaml
@@ -17,13 +17,13 @@ components:
 
   - name: dos-games-test
     files:
-      - source: dos-games-test
-        target: dos-games-test
+      - source: dos-games.test
+        target: dos-games.test
         executable: true
     actions:
       onDeploy:
         after:
-          - cmd: ./dos-games-test -test.v
+          - cmd: ./dos-games.test -test.v
       onCreate:
         before:
-          - cmd: go test -c -o dos-games-test
+          - cmd: go test -c -o dos-games.test


### PR DESCRIPTION
Fixing typo of dos-games-test to dos-games.test where applicable in the zarf.yaml for the dos-games example.